### PR TITLE
Only play one audio response at a time

### DIFF
--- a/src/context/AudioPlaybackContext.tsx
+++ b/src/context/AudioPlaybackContext.tsx
@@ -1,0 +1,59 @@
+import React, { createContext, Dispatch, useContext, useEffect, useRef, useState } from 'react';
+
+export type PlaybackState = {
+    src?: string,
+    playing: boolean,
+};
+
+export type AudioPlaybackContextValue = [
+    PlaybackState,
+    Dispatch<PlaybackState>,
+];
+
+const AudioPlaybackContext = createContext<AudioPlaybackContextValue>([
+    { playing: false }, () => {}]);
+
+export type AudioPlaybackProviderProps = {
+    children: React.ReactNode,
+};
+
+export function AudioPlaybackProvider({ children }: AudioPlaybackProviderProps) {
+    const refContainer = useRef<HTMLAudioElement>(null)
+    const [playback, setPlayback] = useState<PlaybackState>({ playing: false });
+
+    useEffect(() => {
+        const handleEnded = () => setPlayback({
+            playing: false,
+        });
+        refContainer.current?.addEventListener('ended', handleEnded);
+        refContainer.current?.addEventListener('pause', handleEnded);
+        return function cleanup() {
+            refContainer.current?.removeEventListener('ended', handleEnded);
+            refContainer.current?.removeEventListener('pause', handleEnded);
+        };
+    }, [playback, setPlayback, refContainer.current]);
+
+    useEffect(() => {
+        (async () => {
+            if (playback.playing) {
+                try {
+                    await refContainer.current?.play();
+                } catch (e) {
+                    console.warn(`Playback failed for ${playback.src}`);
+                    setPlayback({ playing: false });
+                }
+            } else {
+                refContainer.current?.pause();
+            }
+        })();
+    }, [playback.playing, playback.src, refContainer.current]);
+
+    return (
+        <AudioPlaybackContext.Provider value={[playback, setPlayback]}>
+            <audio ref={refContainer} src={playback.src} />
+            {children}
+        </AudioPlaybackContext.Provider>
+    );
+}
+
+export const useAudioPlayback = () => useContext(AudioPlaybackContext);

--- a/src/context/SettingsContext.tsx
+++ b/src/context/SettingsContext.tsx
@@ -17,7 +17,7 @@ type SettingsContextValue = [
 const SettingsContext = createContext<SettingsContextValue>([defaultSettings, () => {}]);
 
 export function SettingsProvider(props: { defaultValue?: Settings, children: React.ReactNode }) {
-    const [stored, _setStored] = useLocalStorage<Settings>('@sdifi:settings', defaultSettings);
+    const [stored, _setStored] = useLocalStorage<Settings>('@sdifi:settings', props.defaultValue ?? defaultSettings);
     const setStored = useCallback(_setStored, []);
     const ctxValue = useMemo<SettingsContextValue>(() => [stored, setStored], [stored, setStored]);
 

--- a/src/hooks/useReducerWithMiddleware.ts
+++ b/src/hooks/useReducerWithMiddleware.ts
@@ -1,0 +1,29 @@
+import React, { useEffect, useReducer, useRef } from 'react';
+
+/**
+ * Reducer hook with multiple middleware functions and multiple afterware functions for side-effects.
+ */
+export function useReducerWithMiddleware<S, A>(
+    reducer: React.Reducer<S, A>,
+    initialState: S,
+    middlewareFns: Array<(action: A, state: S) => void>,
+    afterwareFns: Array<(action: A, state: S) => void>): [S, React.Dispatch<A>] {
+    const [state, dispatch] = useReducer(reducer, initialState);
+    const actionRef = useRef<A>();
+
+    const dispatchWithMiddleware: React.Dispatch<A> = (action: A) => {
+        middlewareFns.forEach((fn) => fn(action, state));
+        actionRef.current = action;
+        dispatch(action);
+    };
+
+    useEffect(() => {
+        if (!actionRef.current)
+            return;
+        afterwareFns.forEach((fn) => actionRef.current && fn(actionRef.current, state));
+        actionRef.current = undefined;
+
+    }, [afterwareFns, state]);
+
+    return [state, dispatchWithMiddleware];
+}

--- a/src/views/ConnectedChat.tsx
+++ b/src/views/ConnectedChat.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import Chat from '../components/Chat';
 import { SimpleInfoProps } from '../components/Info';
+import { AudioPlaybackProvider } from '../context/AudioPlaybackContext';
 import { ConversationContextProvider } from '../context/ConversationContext';
 import { MasdifContextProvider } from '../context/MasdifClientContext';
 import { SettingsProvider } from '../context/SettingsContext';
@@ -36,24 +37,26 @@ export default function ConnectedChat(props: ConnectedChatProps) {
     return (
         <SettingsProvider defaultValue={{ disableTTS: props.disableTTS }}>
             <MasdifContextProvider serverAddress={props.serverAddress}>
-                <ConversationContextProvider>
-                    <Chat
-                        title={props.title || "SDiFI"}
-                        subtitle={props.subtitle || "Botti"}
-                        placeholder={props.placeholder || "Spyrðu mig spjörunum úr..."}
-                        hideSettings={props.hideSettings}
-                        hideMute={props.hideMute}
-                        info={props.info || {
-                            paragraphs: [
-                                ('Þetta snjallmenni er hluti af SDiFI, sem er samstarfsþróunarverkefni ' +
-                                    'Háskólans í Reykjavík, Grammatek og Tiro.'),
-                                'Snjallmennið <b>Jóakim</b> veit ekkert voða mikið, en getur svarað spurningum um Andabæ.'
-                            ],
-                            footer: '<a href="https://github.com/sdifi" target="_blank">SDiFI</a>',
-                        }}
-                        startClosed={props.startClosed}
-                    />
-                </ConversationContextProvider>
+                <AudioPlaybackProvider>
+                    <ConversationContextProvider>
+                        <Chat
+                            title={props.title || "SDiFI"}
+                            subtitle={props.subtitle || "Botti"}
+                            placeholder={props.placeholder || "Spyrðu mig spjörunum úr..."}
+                            hideSettings={props.hideSettings}
+                            hideMute={props.hideMute}
+                            info={props.info || {
+                                paragraphs: [
+                                    ('Þetta snjallmenni er hluti af SDiFI, sem er samstarfsþróunarverkefni ' +
+                                     'Háskólans í Reykjavík, Grammatek og Tiro.'),
+                                    'Snjallmennið <b>Jóakim</b> veit ekkert voða mikið, en getur svarað spurningum um Andabæ.'
+                                ],
+                                footer: '<a href="https://github.com/sdifi" target="_blank">SDiFI</a>',
+                            }}
+                            startClosed={props.startClosed}
+                        />
+                    </ConversationContextProvider>
+                </AudioPlaybackProvider>
             </MasdifContextProvider>
         </SettingsProvider>
     );


### PR DESCRIPTION
This closes issues #9 and #10. Responses with audio attachments are now only
played when received and any new response containing audio will stop the current
audio.