### PR TITLE
Use middleware to play audio instead of afterware

### DIFF
--- a/src/context/ConversationContext.tsx
+++ b/src/context/ConversationContext.tsx
@@ -65,9 +65,10 @@ const reducer: React.Reducer<ConversationState, ConversationAction> = (state: Co
     }
 };
 
-const makePlaybackAfterware = (setPlaybackFn: (playbackState: PlaybackState) => void) =>
+const makePlaybackMiddleware = (setPlaybackFn: (playbackState: PlaybackState) => void) =>
     (action: ConversationAction, /* state: ConversationState */) => {
         if (action.type === 'ADD_RESPONSE') {
+            console.debug('response data', action.data)
             const audioAttachment = action.data?.attachment?.find((attachment) => attachment.type === 'audio');
             if (audioAttachment) {
                 setPlaybackFn({
@@ -92,8 +93,8 @@ export type Props = {
 export function ConversationContextProvider(props: Props) {
     const [savedState, setSavedState] = useSessionStorage<ConversationState>('@sdifi:conversation', initialState);
     const [, setPlayback] = useAudioPlayback();
-    const playbackAfterware = makePlaybackAfterware(setPlayback);
-    const [state, dispatch] = useReducerWithMiddleware(reducer, savedState, [], [playbackAfterware]);
+    const playbackMiddleware = makePlaybackMiddleware(setPlayback);
+    const [state, dispatch] = useReducerWithMiddleware(reducer, savedState, [playbackMiddleware], []);
 
     useEffect(() => {
         console.debug('saving state for session');

--- a/src/hooks/useReducerWithMiddleware.ts
+++ b/src/hooks/useReducerWithMiddleware.ts
@@ -1,7 +1,8 @@
 import React, { useEffect, useReducer, useRef } from 'react';
 
 /**
- * Reducer hook with multiple middleware functions and multiple afterware functions for side-effects.
+ * Reducer hook with multiple middleware functions and multiple afterware functions for side-effects. Note that the
+   afterware functions will miss everything but the last dispatch in a rapid sequence.
  */
 export function useReducerWithMiddleware<S, A>(
     reducer: React.Reducer<S, A>,


### PR DESCRIPTION
Closes #29.

The afterware implementation relies on useEffect, which is not fired for each
action if dispatch is called in rapid succession, e.g. when iterating through
server responses.