### PR TITLE
Support image links in responses

### DIFF
--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -14,9 +14,8 @@ export type ConversationSentMessage = {
 
 export type ConversationAttachment =
     | { type: 'audio', payload: { src: string } }
-    | { type: 'image', payload: { title?: string, src: string } }
-    | { type: 'audio', payload: { src: string } }
-    | { type: 'video', payload: { title: string, src: string } }
+    | { type: 'image', payload: { title?: string, link?: string, src: string } }
+    | { type: 'video', payload: { title: string, link?: string, src: string } }
 ;
 
 export type Button = { content_type?: 'text', title: string } & (

--- a/src/components/reply-components.tsx
+++ b/src/components/reply-components.tsx
@@ -140,20 +140,29 @@ const ReplyAudio = styled(function ReplyAudio(props: ReplyAudioProps & { classNa
   }
 `;
 
-
 type ReplyImageProps = {
     src?: string,
     alt?: string,
     title?: string,
+    // Image is a link if present
+    link?: string,
 };
 
-function ReplyImage({ src, alt, title }: ReplyImageProps) {
+function ReplyImage({ src, alt, title, link }: ReplyImageProps) {
     if (!src)
         return null;
 
-    return (
-        <img src={src} alt={alt} title={title} />
-    );
+    const image = <img src={src} alt={alt} title={title} />;
+
+    if (link) {
+        return (
+            <a href={link} target="_blank">
+                {image}
+            </a>
+        );
+    }
+
+    return image;
 }
 
 type ReplyAttachmentsProps = {
@@ -178,6 +187,7 @@ function ReplyAttachments({ attachments }: ReplyAttachmentsProps) {
                             <ReplyImage
                                 key={attachmentData.payload.src}
                                 src={attachmentData.payload.src}
+                                link={attachmentData.payload.link}
                             />
                         );
                     default:


### PR DESCRIPTION
Closes #31.

Handle image attachments with an optional `link` property in the payload and
make the image a link with that URL.