### PR TITLE
Add max-width for image responses to theme

### DIFF
--- a/src/components/Messages.tsx
+++ b/src/components/Messages.tsx
@@ -61,7 +61,7 @@ const BotMessageContainer = styled.div`
   max-width: 85%;
 
   img {
-    max-width: 180px;
+    max-width: ${({theme}) => theme.botMessageMaxImageWidth};
   }
 `;
 

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -21,6 +21,7 @@ export const defaultTheme: DefaultTheme = {
     botAvatarImageSize: '30px',
     botMessageBgColor: '#f4f7f9',
     botMessageFgColor: '#000',
+    botMessageMaxImageWidth: '100%',
 
     formFgColor: '#000',
     formBgColor: '#f4f7f9',

--- a/src/theme/styled.d.ts
+++ b/src/theme/styled.d.ts
@@ -23,6 +23,7 @@ declare module 'styled-components' {
         botAvatarImageSize: string,
         botMessageBgColor: string,
         botMessageFgColor: string,
+        botMessageMaxImageWidth: string,
 
         formFgColor: string,
         formBgColor: string,


### PR DESCRIPTION
This PR adds max width of images to the theme and defaults to 100% of the bot
message container.

Closes #30.